### PR TITLE
openapi-loader: model dependencies + fix watch

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,6 @@ npm install
 npm run watch
 ```
 
-Note: this will NOT watch changes to files in the specs directory except for `openapi.json`
-
 ### Build for deployment
 
 ```bash

--- a/loaders/openapi-loader.js
+++ b/loaders/openapi-loader.js
@@ -1,8 +1,10 @@
 const SwaggerParser = require('@apidevtools/swagger-parser');
-
+const path = require( 'path' );
 
 module.exports = function (_) {
     const done = this.async();
+
+    this.addContextDependency( path.dirname( this.resourcePath ) );
 
     SwaggerParser.bundle(this.resourcePath)
         .then(spec => done(null, JSON.stringify(spec)))


### PR DESCRIPTION
openapi.json, through $ref, pulls in many other files - they all sit in
the same directory but otherwise their interdependency is opaque to
webpack. We have to make that explicit (a bit bluntly).