### PR TITLE
add authorization and resulting error responses

### DIFF
--- a/specs/global/responses.json
+++ b/specs/global/responses.json
@@ -18,6 +18,22 @@
             }
         }
     },
+    "UnauthenticatedError": {
+        "description": "An authentication error has occurred. This can happen due to missing authentication (i.e. no token presented) on resources which require it.",
+        "content": {
+            "application/json": {
+                "schema": { "$ref": "./schemas.json#/Error" }
+            }
+        }
+    },
+    "UnauthorizedError": {
+        "description": "An authorization error has occurred. This can happen if an authenticated user has insufficient privileges.",
+        "content": {
+            "application/json": {
+                "schema": { "$ref": "./schemas.json#/Error" }
+            }
+        }
+    },
     "Entity": {
         "description": "A single wikibase entity",
         "content": {

--- a/specs/openapi.json
+++ b/specs/openapi.json
@@ -16,6 +16,12 @@
         },
         "schemas": {
             "$ref": "./global/schemas.json"
+        },
+        "securitySchemes": {
+            "bearerAuth": {
+                "type": "http",
+                "scheme": "bearer"
+            }
         }
     },
     "tags": [
@@ -46,5 +52,8 @@
     ],
     "paths": {
         "$ref": "./paths/index.json"
-    }
+    },
+    "security": [
+        { "bearerAuth": [] }
+    ]
 }

--- a/specs/paths/entities/aliases/list.json
+++ b/specs/paths/entities/aliases/list.json
@@ -26,6 +26,8 @@
         "responses": {
             "200": { "$ref": "../../../global/responses.json#/EntityAliasesList" },
             "404": { "$ref": "../../../global/responses.json#/NotFound" },
+            "501": { "$ref": "../../../global/responses.json#/UnauthenticatedError" },
+            "503": { "$ref": "../../../global/responses.json#/UnauthorizedError" },
             "default": { "$ref": "../../../global/responses.json#/UnexpectedError" }
         }
     }

--- a/specs/paths/entities/aliases/singleLang.json
+++ b/specs/paths/entities/aliases/singleLang.json
@@ -27,6 +27,8 @@
         "responses": {
             "200": { "$ref": "../../../global/responses.json#/EntityDescription" },
             "404": { "$ref": "../../../global/responses.json#/NotFound" },
+            "501": { "$ref": "../../../global/responses.json#/UnauthenticatedError" },
+            "503": { "$ref": "../../../global/responses.json#/UnauthorizedError" },
             "default": { "$ref": "../../../global/responses.json#/UnexpectedError" }
         }
     },
@@ -42,6 +44,8 @@
         "responses": {
             "200": { "$ref": "../../../global/responses.json#/EntityAliases" },
             "404": { "$ref": "../../../global/responses.json#/NotFound" },
+            "501": { "$ref": "../../../global/responses.json#/UnauthenticatedError" },
+            "503": { "$ref": "../../../global/responses.json#/UnauthorizedError" },
             "default": { "$ref": "../../../global/responses.json#/UnexpectedError" }
         }
     },
@@ -57,6 +61,8 @@
         "responses": {
             "200": { "$ref": "../../../global/responses.json#/OK" },
             "404": { "$ref": "../../../global/responses.json#/NotFound" },
+            "501": { "$ref": "../../../global/responses.json#/UnauthenticatedError" },
+            "503": { "$ref": "../../../global/responses.json#/UnauthorizedError" },
             "default": { "$ref": "../../../global/responses.json#/UnexpectedError" }
         }
     }

--- a/specs/paths/entities/descriptions/list.json
+++ b/specs/paths/entities/descriptions/list.json
@@ -12,6 +12,8 @@
         "responses": {
             "200": { "$ref": "../../../global/responses.json#/EntityDescriptionList" },
             "404": { "$ref": "../../../global/responses.json#/NotFound" },
+            "501": { "$ref": "../../../global/responses.json#/UnauthenticatedError" },
+            "503": { "$ref": "../../../global/responses.json#/UnauthorizedError" },
             "default": { "$ref": "../../../global/responses.json#/UnexpectedError" }
         }
     },
@@ -26,6 +28,8 @@
         "responses": {
             "200": { "$ref": "../../../global/responses.json#/EntityDescriptionList" },
             "404": { "$ref": "../../../global/responses.json#/NotFound" },
+            "501": { "$ref": "../../../global/responses.json#/UnauthenticatedError" },
+            "503": { "$ref": "../../../global/responses.json#/UnauthorizedError" },
             "default": { "$ref": "../../../global/responses.json#/UnexpectedError" }
         }
     }

--- a/specs/paths/entities/descriptions/singleLang.json
+++ b/specs/paths/entities/descriptions/singleLang.json
@@ -25,6 +25,8 @@
         "responses": {
             "200": { "$ref": "../../../global/responses.json#/EntityDescription" },
             "404": { "$ref": "../../../global/responses.json#/NotFound" },
+            "501": { "$ref": "../../../global/responses.json#/UnauthenticatedError" },
+            "503": { "$ref": "../../../global/responses.json#/UnauthorizedError" },
             "default": { "$ref": "../../../global/responses.json#/UnexpectedError" }
         }
     },
@@ -40,6 +42,8 @@
         "responses": {
             "200": { "$ref": "../../../global/responses.json#/OK" },
             "404": { "$ref": "../../../global/responses.json#/NotFound" },
+            "501": { "$ref": "../../../global/responses.json#/UnauthenticatedError" },
+            "503": { "$ref": "../../../global/responses.json#/UnauthorizedError" },
             "default": { "$ref": "../../../global/responses.json#/UnexpectedError" }
         }
     }

--- a/specs/paths/entities/items/sitelinks/list.json
+++ b/specs/paths/entities/items/sitelinks/list.json
@@ -24,6 +24,8 @@
         "responses": {
             "200": { "$ref": "../../../../global/responses.json#/SitelinkList" },
             "404": { "$ref": "../../../../global/responses.json#/NotFound" },
+            "501": { "$ref": "../../../../global/responses.json#/UnauthenticatedError" },
+            "503": { "$ref": "../../../../global/responses.json#/UnauthorizedError" },
             "default": { "$ref": "../../../../global/responses.json#/UnexpectedError" }
         }
     }

--- a/specs/paths/entities/items/sitelinks/single.json
+++ b/specs/paths/entities/items/sitelinks/single.json
@@ -23,6 +23,8 @@
         "responses": {
             "200": { "$ref": "../../../../global/responses.json#/Sitelink" },
             "404": { "$ref": "../../../../global/responses.json#/NotFound" },
+            "501": { "$ref": "../../../../global/responses.json#/UnauthenticatedError" },
+            "503": { "$ref": "../../../../global/responses.json#/UnauthorizedError" },
             "default": { "$ref": "../../../../global/responses.json#/UnexpectedError" }
         }
     },
@@ -37,6 +39,8 @@
         "responses": {
             "200": { "$ref": "../../../../global/responses.json#/OK" },
             "404": { "$ref": "../../../../global/responses.json#/NotFound" },
+            "501": { "$ref": "../../../../global/responses.json#/UnauthenticatedError" },
+            "503": { "$ref": "../../../../global/responses.json#/UnauthorizedError" },
             "default": { "$ref": "../../../../global/responses.json#/UnexpectedError" }
         }
     },

--- a/specs/paths/entities/list.json
+++ b/specs/paths/entities/list.json
@@ -25,6 +25,8 @@
         "responses": {
             "200": { "$ref": "../../global/responses.json#/Entity" },
             "404": { "$ref": "../../global/responses.json#/NotFound" },
+            "501": { "$ref": "../../global/responses.json#/UnauthenticatedError" },
+            "503": { "$ref": "../../global/responses.json#/UnauthorizedError" },
             "default": { "$ref": "../../global/responses.json#/UnexpectedError" }
         }
     }

--- a/specs/paths/entities/single.json
+++ b/specs/paths/entities/single.json
@@ -24,6 +24,8 @@
         "responses": {
             "200": { "$ref": "../../global/responses.json#/Entity" },
             "404": { "$ref": "../../global/responses.json#/NotFound" },
+            "501": { "$ref": "../../global/responses.json#/UnauthenticatedError" },
+            "503": { "$ref": "../../global/responses.json#/UnauthorizedError" },
             "default": { "$ref": "../../global/responses.json#/UnexpectedError" }
         }
     },
@@ -38,6 +40,8 @@
         "responses": {
             "200": { "$ref": "../../global/responses.json#/Entity" },
             "404": { "$ref": "../../global/responses.json#/NotFound" },
+            "501": { "$ref": "../../global/responses.json#/UnauthenticatedError" },
+            "503": { "$ref": "../../global/responses.json#/UnauthorizedError" },
             "default": { "$ref": "../../global/responses.json#/UnexpectedError" }
         }
     },
@@ -52,6 +56,8 @@
         "responses": {
             "200": { "$ref": "../../global/responses.json#/OK" },
             "404": { "$ref": "../../global/responses.json#/NotFound" },
+            "501": { "$ref": "../../global/responses.json#/UnauthenticatedError" },
+            "503": { "$ref": "../../global/responses.json#/UnauthorizedError" },
             "default": { "$ref": "../../global/responses.json#/UnexpectedError" }
         }
     }

--- a/specs/paths/statements/list.json
+++ b/specs/paths/statements/list.json
@@ -27,6 +27,8 @@
         "responses": {
             "200": { "$ref": "../../global/responses.json#/Statement" },
             "404": { "$ref": "../../global/responses.json#/NotFound" },
+            "501": { "$ref": "../../global/responses.json#/UnauthenticatedError" },
+            "503": { "$ref": "../../global/responses.json#/UnauthorizedError" },
             "default": { "$ref": "../../global/responses.json#/UnexpectedError" }
         }
     }

--- a/specs/paths/statements/qualifiers/list.json
+++ b/specs/paths/statements/qualifiers/list.json
@@ -27,6 +27,8 @@
         "responses": {
             "200": { "$ref": "../../../global/responses.json#/QualifierHash" },
             "404": { "$ref": "../../../global/responses.json#/NotFound" },
+            "501": { "$ref": "../../../global/responses.json#/UnauthenticatedError" },
+            "503": { "$ref": "../../../global/responses.json#/UnauthorizedError" },
             "default": { "$ref": "../../../global/responses.json#/UnexpectedError" }
         }
     }

--- a/specs/paths/statements/qualifiers/single.json
+++ b/specs/paths/statements/qualifiers/single.json
@@ -26,6 +26,8 @@
         "responses": {
             "200": { "$ref": "../../../global/responses.json#/QualifierHash" },
             "404": { "$ref": "../../../global/responses.json#/NotFound" },
+            "501": { "$ref": "../../../global/responses.json#/UnauthenticatedError" },
+            "503": { "$ref": "../../../global/responses.json#/UnauthorizedError" },
             "default": { "$ref": "../../../global/responses.json#/UnexpectedError" }
         }
     },
@@ -41,6 +43,8 @@
         "responses": {
             "200": { "$ref": "../../../global/responses.json#/OK" },
             "404": { "$ref": "../../../global/responses.json#/NotFound" },
+            "501": { "$ref": "../../../global/responses.json#/UnauthenticatedError" },
+            "503": { "$ref": "../../../global/responses.json#/UnauthorizedError" },
             "default": { "$ref": "../../../global/responses.json#/UnexpectedError" }
         }
     }

--- a/specs/paths/statements/references/list.json
+++ b/specs/paths/statements/references/list.json
@@ -27,6 +27,8 @@
         "responses": {
             "200": { "$ref": "../../../global/responses.json#/ReferenceHash" },
             "404": { "$ref": "../../../global/responses.json#/NotFound" },
+            "501": { "$ref": "../../../global/responses.json#/UnauthenticatedError" },
+            "503": { "$ref": "../../../global/responses.json#/UnauthorizedError" },
             "default": { "$ref": "../../../global/responses.json#/UnexpectedError" }
         }
     }

--- a/specs/paths/statements/references/single.json
+++ b/specs/paths/statements/references/single.json
@@ -26,6 +26,8 @@
         "responses": {
             "200": { "$ref": "../../../global/responses.json#/ReferenceHash" },
             "404": { "$ref": "../../../global/responses.json#/NotFound" },
+            "501": { "$ref": "../../../global/responses.json#/UnauthenticatedError" },
+            "503": { "$ref": "../../../global/responses.json#/UnauthorizedError" },
             "default": { "$ref": "../../../global/responses.json#/UnexpectedError" }
         }
     },
@@ -41,6 +43,8 @@
         "responses": {
             "200": { "$ref": "../../../global/responses.json#/OK" },
             "404": { "$ref": "../../../global/responses.json#/NotFound" },
+            "501": { "$ref": "../../../global/responses.json#/UnauthenticatedError" },
+            "503": { "$ref": "../../../global/responses.json#/UnauthorizedError" },
             "default": { "$ref": "../../../global/responses.json#/UnexpectedError" }
         }
     }

--- a/specs/paths/statements/single.json
+++ b/specs/paths/statements/single.json
@@ -23,6 +23,8 @@
         "responses": {
             "200": { "$ref": "../../global/responses.json#/Statement" },
             "404": { "$ref": "../../global/responses.json#/NotFound" },
+            "501": { "$ref": "../../global/responses.json#/UnauthenticatedError" },
+            "503": { "$ref": "../../global/responses.json#/UnauthorizedError" },
             "default": { "$ref": "../../global/responses.json#/UnexpectedError" }
         }
     },
@@ -36,6 +38,8 @@
         "responses": {
             "200": { "$ref": "../../global/responses.json#/Statement" },
             "404": { "$ref": "../../global/responses.json#/NotFound" },
+            "501": { "$ref": "../../global/responses.json#/UnauthenticatedError" },
+            "503": { "$ref": "../../global/responses.json#/UnauthorizedError" },
             "default": { "$ref": "../../global/responses.json#/UnexpectedError" }
         }
     },
@@ -50,6 +54,8 @@
         "responses": {
             "200": { "$ref": "../../global/responses.json#/OK" },
             "404": { "$ref": "../../global/responses.json#/NotFound" },
+            "501": { "$ref": "../../global/responses.json#/UnauthenticatedError" },
+            "503": { "$ref": "../../global/responses.json#/UnauthorizedError" },
             "default": { "$ref": "../../global/responses.json#/UnexpectedError" }
         }
     }


### PR DESCRIPTION
This adds a global security scheme "bearerAuth" (which is optional) and
error responses to resources which can be affected. It provides a way
for users who are already authenticated (e.g. through OAuth or other
ways to become the "Bearer" of a token) to present their credentials. It
does not provide a solution for "Callers using cookie-based
authentication" as seen in the action API or mentioned in [0].

Generally, editing is possible as anonymous, but some resources (e.g.
[semi-protected] "pages"/entities) require elevated privileges and
attempts to manipulate their resources can lead to
authentication/authorization errors.

In contrast, to my knowledge, there is no existing way to read-protect
only some entities - consequently possible authentication/authorization
errors were only added to manipulations of resources.

See
https://swagger.io/docs/specification/authentication/bearer-authentication/

[0]: https://www.mediawiki.org/wiki/API:REST_API/Reference#Create_page