### PR TITLE
make it explicit that auth is optional

### DIFF
--- a/specs/openapi.json
+++ b/specs/openapi.json
@@ -3,7 +3,7 @@
     "info": {
         "title":"Wikibase REST API Proposal",
         "version":"1.0",
-        "description": "<p>This is a proposal for the structure of the future Wikibase REST API.</p>"
+        "description": "<p>This is a proposal for the structure of the future Wikibase REST API.</p><h2>Authentication</h2><p>Authentication is optional for all paths but individual resources may require it (e.g. particular items).</p>",
     },
     "servers": [
         { "url":"https://www.wikidata.org/w/rest.php/wikibase/v0" }
@@ -55,6 +55,7 @@
         "$ref": "./paths/index.json"
     },
     "security": [
+        {},
         { "bearerAuth": [] }
     ]
 }

--- a/specs/openapi.json
+++ b/specs/openapi.json
@@ -2,7 +2,8 @@
     "openapi":"3.0.2",
     "info": {
         "title":"Wikibase REST API Proposal",
-        "version":"1.0"
+        "version":"1.0",
+        "description": "<p>This is a proposal for the structure of the future Wikibase REST API.</p>"
     },
     "servers": [
         { "url":"https://www.wikidata.org/w/rest.php/wikibase/v0" }


### PR DESCRIPTION
Auth was added in c077573. Most/All our endpoints are available without
authentication (but some records may be protected) - let's make it
explicit that unauthenticated use is legitimate.

As far as I can tell this has no impact in swagger ui, though.

See
https://github.com/OAI/OpenAPI-Specification/issues/14