### PR TITLE
Unhash reference snaks

### DIFF
--- a/specs/global/interfaces.json
+++ b/specs/global/interfaces.json
@@ -24,13 +24,8 @@
     },
     "HashedSnak": {
         "allOf": [
-            {
-                "$ref": "#/Snak"
-            },
-            {
-                "type": "object",
-                "properties": { "hash": { "$ref": "#/SnakHash" } }
-            }
+            { "$ref": "#/Snak" },
+            { "$ref": "#/HashBearing" }
         ]
     },
     "HashedSnakList": {

--- a/specs/global/schemas.json
+++ b/specs/global/schemas.json
@@ -197,7 +197,7 @@
                 "type": "object",
                 "properties": {
                     "snaks": {
-                        "$ref": "./interfaces.json#/HashedSnakMap"
+                        "$ref": "./interfaces.json#/SnakMap"
                     }
                 }
             }


### PR DESCRIPTION
Really tiny PR for something I noticed, References have a SnakMap and not a HashedSnakMap. Also fixes the following bug:


![Screenshot from 2020-09-22 10-47-02](https://user-images.githubusercontent.com/6132917/93861677-323d7e80-fcc1-11ea-9fe0-fbf78f616df3.png)

