### PR TITLE
Separate Items and Properties

### DIFF
--- a/specs/global/interfaces.json
+++ b/specs/global/interfaces.json
@@ -1,4 +1,26 @@
 {
+    "Entity": {
+        "type": "object",
+        "properties": {
+            "id": {
+                "type": "string"
+            },
+            "type": {
+                "type": "string"
+            },
+            "modified": {
+                "type": "string",
+                "format": "date-time"
+            }
+        },
+		"required": [
+            "id",
+            "type"
+        ],
+        "discriminator": {
+            "propertyName": "type"
+        }
+    },
     "Fingerprintable": {
         "type": "object",
         "properties": {

--- a/specs/global/payloads.json
+++ b/specs/global/payloads.json
@@ -57,6 +57,16 @@
             }
         }
     },
+    "NewProperty": {
+        "allOf": [
+            {
+                "$ref": "./interfaces.json#/Fingerprintable"
+            },
+            {
+                "$ref": "./interfaces.json#/StatementsBearing"
+            }
+        ]
+    },
     "NewItem": {
         "allOf": [
             {

--- a/specs/global/payloads.json
+++ b/specs/global/payloads.json
@@ -57,6 +57,22 @@
             }
         }
     },
+    "NewItem": {
+        "allOf": [
+            {
+                "$ref": "./interfaces.json#/Fingerprintable"
+            },
+            {
+                "$ref": "./interfaces.json#/StatementsBearing"
+            },
+            {
+                "type": "object",
+                "properties": {
+                    "sitelinks": { "$ref": "./interfaces.json#/SitelinkMap" }
+                }
+            }
+        ]
+    },
     "NewQualifier": {
         "$ref": "./interfaces.json#/Snak"
     },

--- a/specs/global/requests.json
+++ b/specs/global/requests.json
@@ -56,6 +56,25 @@
             }
         }
     },
+    "Item": {
+        "description": "Edit payload containing a Wikibase Item",
+        "required": true,
+        "content": {
+            "application/json": {
+                "schema": {
+                    "allOf": [
+                        {
+                            "type": "object",
+                            "properties": { "item": { "$ref": "./payloads.json#/NewItem" } }
+                        },
+                        {
+                            "$ref": "./payloads.json#/MediawikiEdit"
+                        }
+                    ]
+                }
+            }
+        }
+    },
     "Qualifier": {
         "description": "A Wikibase qualifier object",
         "required": true,

--- a/specs/global/requests.json
+++ b/specs/global/requests.json
@@ -84,7 +84,7 @@
                     "allOf": [
                         {
                             "type": "object",
-                            "properties": { "entity": { "$ref": "./schemas.json#/NewProperty" } }
+                            "properties": { "property": { "$ref": "./payloads.json#/NewProperty" } }
                         },
                         {
                             "$ref": "./payloads.json#/MediawikiEdit"

--- a/specs/global/requests.json
+++ b/specs/global/requests.json
@@ -75,6 +75,25 @@
             }
         }
     },
+    "Property": {
+        "description": "Edit payload containing a Wikibase Property",
+        "required": true,
+        "content": {
+            "application/json": {
+                "schema": {
+                    "allOf": [
+                        {
+                            "type": "object",
+                            "properties": { "entity": { "$ref": "./schemas.json#/NewProperty" } }
+                        },
+                        {
+                            "$ref": "./payloads.json#/MediawikiEdit"
+                        }
+                    ]
+                }
+            }
+        }
+    },
     "Qualifier": {
         "description": "A Wikibase qualifier object",
         "required": true,

--- a/specs/global/requests.json
+++ b/specs/global/requests.json
@@ -37,25 +37,6 @@
             }
         }
     },
-    "Entity": {
-        "description": "Edit payload containing a Wikibase entity object (Item / Property)",
-        "required": true,
-        "content": {
-            "application/json": {
-                "schema": {
-                    "allOf": [
-                        {
-                            "type": "object",
-                            "properties": { "entity": { "$ref": "./schemas.json#/Entity" } }
-                        },
-                        {
-                            "$ref": "./payloads.json#/MediawikiEdit"
-                        }
-                    ]
-                }
-            }
-        }
-    },
     "Item": {
         "description": "Edit payload containing a Wikibase Item",
         "required": true,

--- a/specs/global/responses.json
+++ b/specs/global/responses.json
@@ -65,28 +65,6 @@
             }
         }
     },
-    "Entity": {
-        "description": "A single wikibase entity",
-        "headers": {
-            "Last-Modified": {
-                "schema": {
-                    "type": "string"
-                },
-                "description": "Last modified date"
-            },
-            "ETag": {
-                "schema": {
-                    "type": "string"
-                },
-                "description": "Last entity revision number"
-            }
-        },
-        "content": {
-            "application/json": {
-                "schema": { "$ref": "./schemas.json#/Entity" }
-            }
-        }
-    },
     "Property": {
         "description": "A single Wikibase Property",
         "headers": {
@@ -128,22 +106,6 @@
         "content": {
             "application/json": {
                 "schema": { "$ref": "./schemas.json#/Item" }
-            }
-        }
-    },
-    "EntityList": {
-        "description": "A list of wikibase entities",
-        "content": {
-            "application/json": {
-                "schema": {
-                    "type": "object",
-                    "properties": {
-                        "entities": {
-                            "type": "array",
-                            "items": { "$ref": "./schemas.json#/Entity" }
-                        }
-                    }
-                }
             }
         }
     },

--- a/specs/global/responses.json
+++ b/specs/global/responses.json
@@ -87,6 +87,28 @@
             }
         }
     },
+    "Item": {
+        "description": "A single wikibase item",
+        "headers": {
+            "Last-Modified": {
+                "schema": {
+                    "type": "string"
+                },
+                "description": "Last modified date"
+            },
+            "ETag": {
+                "schema": {
+                    "type": "string"
+                },
+                "description": "Last entity revision number"
+            }
+        },
+        "content": {
+            "application/json": {
+                "schema": { "$ref": "./schemas.json#/Item" }
+            }
+        }
+    },
     "EntityList": {
         "description": "A list of wikibase entities",
         "content": {
@@ -97,6 +119,22 @@
                         "entities": {
                             "type": "array",
                             "items": { "$ref": "./schemas.json#/Entity" }
+                        }
+                    }
+                }
+            }
+        }
+    },
+    "ItemList": {
+        "description": "A list of wikibase items",
+        "content": {
+            "application/json": {
+                "schema": {
+                    "type": "object",
+                    "properties": {
+                        "items": {
+                            "type": "array",
+                            "items": { "$ref": "./schemas.json#/Item" }
                         }
                     }
                 }

--- a/specs/global/responses.json
+++ b/specs/global/responses.json
@@ -87,6 +87,28 @@
             }
         }
     },
+    "Property": {
+        "description": "A single Wikibase Property",
+        "headers": {
+            "Last-Modified": {
+                "schema": {
+                    "type": "string"
+                },
+                "description": "Last modified date"
+            },
+            "ETag": {
+                "schema": {
+                    "type": "string"
+                },
+                "description": "Last entity revision number"
+            }
+        },
+        "content": {
+            "application/json": {
+                "schema": { "$ref": "./schemas.json#/Property" }
+            }
+        }
+    },
     "Item": {
         "description": "A single wikibase item",
         "headers": {
@@ -119,6 +141,22 @@
                         "entities": {
                             "type": "array",
                             "items": { "$ref": "./schemas.json#/Entity" }
+                        }
+                    }
+                }
+            }
+        }
+    },
+    "PropertyList": {
+        "description": "A list of Wikibase Properties",
+        "content": {
+            "application/json": {
+                "schema": {
+                    "type": "object",
+                    "properties": {
+                        "properties": {
+                            "type": "array",
+                            "items": { "$ref": "./schemas.json#/Property" }
                         }
                     }
                 }

--- a/specs/global/schemas.json
+++ b/specs/global/schemas.json
@@ -73,7 +73,7 @@
     "Item": {
         "allOf": [
             {
-                "$ref": "./schemas.json#/Entity"
+                "$ref": "./interfaces.json#/Entity"
             },
             {
                 "$ref": "./interfaces.json#/Fingerprintable"
@@ -92,7 +92,7 @@
     "Property": {
         "allOf": [
             {
-                "$ref": "./schemas.json#/Entity"
+                "$ref": "./interfaces.json#/Entity"
             },
             {
                 "$ref": "./interfaces.json#/Fingerprintable"
@@ -112,28 +112,6 @@
                 ]
             }
         ]
-    },
-    "Entity": {
-        "type": "object",
-        "properties": {
-            "id": {
-                "type": "string"
-            },
-            "type": {
-                "type": "string"
-            },
-            "modified": {
-                "type": "string",
-                "format": "date-time"
-            }
-        },
-		"required": [
-            "id",
-            "type"
-        ],
-        "discriminator": {
-            "propertyName": "type"
-        }
     },
     "Term": {
         "type": "object",

--- a/specs/openapi.json
+++ b/specs/openapi.json
@@ -43,6 +43,14 @@
             }
         },
         {
+            "name": "properties",
+            "description": "Wikibase Properties",
+            "externalDocs": {
+                "description": "Wikibase Datamodel - Properties",
+                "url" : "https://www.mediawiki.org/wiki/Wikibase/DataModel#Properties"
+            }
+        },
+        {
             "name": "statements",
             "description": "Wikibase Statements",
             "externalDocs": {

--- a/specs/openapi.json
+++ b/specs/openapi.json
@@ -27,14 +27,6 @@
     },
     "tags": [
         {
-            "name": "entities",
-            "description": "Wikibase Entities",
-            "externalDocs": {
-                "description": "Wikibase Data Model - Values",
-                "url" : "https://www.mediawiki.org/wiki/Wikibase/DataModel#Values"
-            }
-        },
-        {
             "name": "items",
             "description": "Wikibase Items",
             "externalDocs": {
@@ -48,6 +40,14 @@
             "externalDocs": {
                 "description": "Wikibase Datamodel - Properties",
                 "url" : "https://www.mediawiki.org/wiki/Wikibase/DataModel#Properties"
+            }
+        },
+        {
+            "name": "entities",
+            "description": "Wikibase Entities",
+            "externalDocs": {
+                "description": "Wikibase Data Model - Values",
+                "url" : "https://www.mediawiki.org/wiki/Wikibase/DataModel#Values"
             }
         },
         {

--- a/specs/resources/index.json
+++ b/specs/resources/index.json
@@ -26,6 +26,12 @@
     "/entities/{entity_type}/{entity_id}/statements": {
         "$ref": "./statements/list.json"
     },
+    "/entities/items": {
+        "$ref": "./items/list.json"
+    },
+    "/entities/items/{entity_id}": {
+        "$ref": "./items/single.json"
+    },
     "/entities/items/{entity_id}/sitelinks": {
         "$ref": "./sitelinks/list.json"
     },

--- a/specs/resources/index.json
+++ b/specs/resources/index.json
@@ -1,10 +1,4 @@
 {
-    "/entities/{entity_type}": {
-        "$ref": "./entities/list.json"
-    },
-    "/entities/{entity_type}/{entity_id}": {
-        "$ref": "./entities/single.json"
-    },
     "/entities/{entity_type}/{entity_id}/aliases": {
         "$ref": "./aliases/list.json"
     },
@@ -37,6 +31,12 @@
     },
     "/entities/items/{entity_id}/sitelinks/{wiki_id}": {
         "$ref": "./sitelinks/single.json"
+    },
+    "/entities/properties": {
+        "$ref": "./properties/list.json"
+    },
+    "/entities/properties/{entity_id}": {
+        "$ref": "./properties/single.json"
     },
     "/statements/{statement_id}": {
         "$ref": "./statements/single.json"

--- a/specs/resources/items/list.json
+++ b/specs/resources/items/list.json
@@ -1,0 +1,29 @@
+{
+    "get": {
+        "tags": ["items"],
+        "summary": "Retrieve a list of Wikibase Items",
+        "parameters": [
+            { "$ref": "../../global/parameters.json#/fields" },
+            { "$ref": "../../global/parameters.json#/offset" },
+            { "$ref": "../../global/parameters.json#/page" },
+            { "$ref": "../../global/parameters.json#/per_page" }
+        ],
+        "responses": {
+            "200": { "$ref": "../../global/responses.json#/ItemList" },
+            "404": { "$ref": "../../global/responses.json#/NotFound" },
+            "default": { "$ref": "../../global/responses.json#/UnexpectedError" }
+        }
+    },
+    "post": {
+        "tags": ["items"],
+        "summary": "Create a new Wikibase Item",
+        "requestBody": { "$ref": "../../global/requests.json#/Item" },
+        "responses": {
+            "200": { "$ref": "../../global/responses.json#/Item" },
+            "404": { "$ref": "../../global/responses.json#/NotFound" },
+            "501": { "$ref": "../../global/responses.json#/UnauthenticatedError" },
+            "503": { "$ref": "../../global/responses.json#/UnauthorizedError" },
+            "default": { "$ref": "../../global/responses.json#/UnexpectedError" }
+        }
+    }
+}

--- a/specs/resources/items/single.json
+++ b/specs/resources/items/single.json
@@ -1,7 +1,7 @@
 {
     "get": {
         "tags": [ "items" ],
-        "summary": "Single Entity",
+        "summary": "Single Wikibase Item by Id",
         "parameters": [
             { "$ref": "../../global/parameters.json#/entityId" },
             { "$ref": "../../global/parameters.json#/fields" },
@@ -17,11 +17,11 @@
     },
     "put": {
         "tags": ["items"],
-        "summary": "Replace a Wikibase Entity by Id",
+        "summary": "Replace a Wikibase Item by Id",
         "parameters": [
             { "$ref": "../../global/parameters.json#/entityId" }
         ],
-        "requestBody": { "$ref": "../../global/requests.json#/Entity" },
+        "requestBody": { "$ref": "../../global/responses.json#/Item" },
         "responses": {
             "200": { "$ref": "../../global/responses.json#/Item" },
             "404": { "$ref": "../../global/responses.json#/NotFound" },
@@ -32,7 +32,7 @@
     },
     "patch": {
         "tags": ["items"],
-        "summary": "Update a Wikibase Entity by Id",
+        "summary": "Update a Wikibase Item by Id",
         "parameters": [
             { "$ref": "../../global/parameters.json#/entityId" }
         ],
@@ -47,7 +47,7 @@
     },
     "delete": {
         "tags": [ "items" ],
-        "summary": "Single Entity",
+        "summary": "Delete a Single Item by Id",
         "parameters": [
             { "$ref": "../../global/parameters.json#/entityId" }
         ],

--- a/specs/resources/items/single.json
+++ b/specs/resources/items/single.json
@@ -21,7 +21,7 @@
         "parameters": [
             { "$ref": "../../global/parameters.json#/entityId" }
         ],
-        "requestBody": { "$ref": "../../global/responses.json#/Item" },
+        "requestBody": { "$ref": "../../global/requests.json#/Item" },
         "responses": {
             "200": { "$ref": "../../global/responses.json#/Item" },
             "404": { "$ref": "../../global/responses.json#/NotFound" },

--- a/specs/resources/items/single.json
+++ b/specs/resources/items/single.json
@@ -1,0 +1,63 @@
+{
+    "get": {
+        "tags": [ "items" ],
+        "summary": "Single Entity",
+        "parameters": [
+            { "$ref": "../../global/parameters.json#/entityId" },
+            { "$ref": "../../global/parameters.json#/fields" },
+            { "$ref": "../../global/parameters.json#/ifNoneMatch" },
+            { "$ref": "../../global/parameters.json#/ifModifiedSince" }
+        ],
+        "responses": {
+            "200": { "$ref": "../../global/responses.json#/Item" },
+            "304": { "$ref": "../../global/responses.json#/NotModified" },
+            "404": { "$ref": "../../global/responses.json#/NotFound" },
+            "default": { "$ref": "../../global/responses.json#/UnexpectedError" }
+        }
+    },
+    "put": {
+        "tags": ["items"],
+        "summary": "Replace a Wikibase Entity by Id",
+        "parameters": [
+            { "$ref": "../../global/parameters.json#/entityId" }
+        ],
+        "requestBody": { "$ref": "../../global/requests.json#/Entity" },
+        "responses": {
+            "200": { "$ref": "../../global/responses.json#/Item" },
+            "404": { "$ref": "../../global/responses.json#/NotFound" },
+            "501": { "$ref": "../../global/responses.json#/UnauthenticatedError" },
+            "503": { "$ref": "../../global/responses.json#/UnauthorizedError" },
+            "default": { "$ref": "../../global/responses.json#/UnexpectedError" }
+        }
+    },
+    "patch": {
+        "tags": ["items"],
+        "summary": "Update a Wikibase Entity by Id",
+        "parameters": [
+            { "$ref": "../../global/parameters.json#/entityId" }
+        ],
+        "requestBody": { "$ref": "../../global/requests.json#/PatchList" },
+        "responses": {
+            "200": { "$ref": "../../global/responses.json#/Item" },
+            "404": { "$ref": "../../global/responses.json#/NotFound" },
+            "501": { "$ref": "../../global/responses.json#/UnauthenticatedError" },
+            "503": { "$ref": "../../global/responses.json#/UnauthorizedError" },
+            "default": { "$ref": "../../global/responses.json#/UnexpectedError" }
+        }
+    },
+    "delete": {
+        "tags": [ "items" ],
+        "summary": "Single Entity",
+        "parameters": [
+            { "$ref": "../../global/parameters.json#/entityId" }
+        ],
+        "requestBody": { "$ref": "../../global/requests.json#/Deletion" },
+        "responses": {
+            "200": { "$ref": "../../global/responses.json#/OK" },
+            "404": { "$ref": "../../global/responses.json#/NotFound" },
+            "501": { "$ref": "../../global/responses.json#/UnauthenticatedError" },
+            "503": { "$ref": "../../global/responses.json#/UnauthorizedError" },
+            "default": { "$ref": "../../global/responses.json#/UnexpectedError" }
+        }
+    }
+}

--- a/specs/resources/properties/list.json
+++ b/specs/resources/properties/list.json
@@ -1,29 +1,25 @@
 {
     "get": {
-        "tags": ["entities"],
-        "summary": "Retrieve a list of Wikibase Entities (Items or Properties)",
-        "parameters": [
-            { "$ref": "../../global/parameters.json#/entityType" },
+        "tags": ["properties"],
+        "summary": "Retrieve a list of Wikibase Properties",
+        "parameters": [,
             { "$ref": "../../global/parameters.json#/fields" },
             { "$ref": "../../global/parameters.json#/offset" },
             { "$ref": "../../global/parameters.json#/page" },
             { "$ref": "../../global/parameters.json#/per_page" }
         ],
         "responses": {
-            "200": { "$ref": "../../global/responses.json#/EntityList" },
+            "200": { "$ref": "../../global/responses.json#/PropertyList" },
             "404": { "$ref": "../../global/responses.json#/NotFound" },
             "default": { "$ref": "../../global/responses.json#/UnexpectedError" }
         }
     },
     "post": {
-        "tags": ["entities"],
+        "tags": ["properties"],
         "summary": "Create a new Wikibase Entity",
-        "parameters": [
-            { "$ref": "../../global/parameters.json#/entityType" }
-        ],
-        "requestBody": { "$ref": "../../global/requests.json#/Entity" },
+        "requestBody": { "$ref": "../../global/requests.json#/Property" },
         "responses": {
-            "200": { "$ref": "../../global/responses.json#/Entity" },
+            "200": { "$ref": "../../global/responses.json#/Property" },
             "404": { "$ref": "../../global/responses.json#/NotFound" },
             "501": { "$ref": "../../global/responses.json#/UnauthenticatedError" },
             "503": { "$ref": "../../global/responses.json#/UnauthorizedError" },

--- a/specs/resources/properties/list.json
+++ b/specs/resources/properties/list.json
@@ -2,7 +2,7 @@
     "get": {
         "tags": ["properties"],
         "summary": "Retrieve a list of Wikibase Properties",
-        "parameters": [,
+        "parameters": [
             { "$ref": "../../global/parameters.json#/fields" },
             { "$ref": "../../global/parameters.json#/offset" },
             { "$ref": "../../global/parameters.json#/page" },

--- a/specs/resources/properties/list.json
+++ b/specs/resources/properties/list.json
@@ -16,7 +16,7 @@
     },
     "post": {
         "tags": ["properties"],
-        "summary": "Create a new Wikibase Entity",
+        "summary": "Create a new Wikibase Property",
         "requestBody": { "$ref": "../../global/requests.json#/Property" },
         "responses": {
             "200": { "$ref": "../../global/responses.json#/Property" },

--- a/specs/resources/properties/single.json
+++ b/specs/resources/properties/single.json
@@ -1,31 +1,29 @@
 {
     "get": {
-        "tags": [ "entities" ],
-        "summary": "Single Entity",
+        "tags": [ "properties" ],
+        "summary": "Single Property",
         "parameters": [
-            { "$ref": "../../global/parameters.json#/entityType" },
             { "$ref": "../../global/parameters.json#/entityId" },
             { "$ref": "../../global/parameters.json#/fields" },
             { "$ref": "../../global/parameters.json#/ifNoneMatch" },
             { "$ref": "../../global/parameters.json#/ifModifiedSince" }
         ],
         "responses": {
-            "200": { "$ref": "../../global/responses.json#/Entity" },
+            "200": { "$ref": "../../global/responses.json#/Property" },
             "304": { "$ref": "../../global/responses.json#/NotModified" },
             "404": { "$ref": "../../global/responses.json#/NotFound" },
             "default": { "$ref": "../../global/responses.json#/UnexpectedError" }
         }
     },
     "put": {
-        "tags": ["entities"],
-        "summary": "Replace a Wikibase Entity by Id",
+        "tags": ["properties"],
+        "summary": "Replace a Wikibase Property by Id",
         "parameters": [
-            { "$ref": "../../global/parameters.json#/entityType" },
             { "$ref": "../../global/parameters.json#/entityId" }
         ],
-        "requestBody": { "$ref": "../../global/requests.json#/Entity" },
+        "requestBody": { "$ref": "../../global/requests.json#/Property" },
         "responses": {
-            "200": { "$ref": "../../global/responses.json#/Entity" },
+            "200": { "$ref": "../../global/responses.json#/Property" },
             "404": { "$ref": "../../global/responses.json#/NotFound" },
             "501": { "$ref": "../../global/responses.json#/UnauthenticatedError" },
             "503": { "$ref": "../../global/responses.json#/UnauthorizedError" },
@@ -33,15 +31,14 @@
         }
     },
     "patch": {
-        "tags": ["entities"],
-        "summary": "Update a Wikibase Entity by Id",
+        "tags": ["properties"],
+        "summary": "Update a Wikibase Property by Id",
         "parameters": [
-            { "$ref": "../../global/parameters.json#/entityType" },
             { "$ref": "../../global/parameters.json#/entityId" }
         ],
         "requestBody": { "$ref": "../../global/requests.json#/PatchList" },
         "responses": {
-            "200": { "$ref": "../../global/responses.json#/Entity" },
+            "200": { "$ref": "../../global/responses.json#/Property" },
             "404": { "$ref": "../../global/responses.json#/NotFound" },
             "501": { "$ref": "../../global/responses.json#/UnauthenticatedError" },
             "503": { "$ref": "../../global/responses.json#/UnauthorizedError" },
@@ -49,10 +46,9 @@
         }
     },
     "delete": {
-        "tags": [ "entities" ],
-        "summary": "Single Entity",
+        "tags": [ "properties" ],
+        "summary": "Remove a Single Property by Id",
         "parameters": [
-            { "$ref": "../../global/parameters.json#/entityType" },
             { "$ref": "../../global/parameters.json#/entityId" }
         ],
         "requestBody": { "$ref": "../../global/requests.json#/Deletion" },


### PR DESCRIPTION
Separate Item and Property endpoints. This is the 3rd and last PR in a chain intended to separate the item and property endpoints for the sake of better response documentation. Depends on PR #74 . (NB: There is one more PR in this chain but this should serve  as an optional suggestion to improve the UI)