### PR TITLE
Suggestion: Restructure tags

### DIFF
--- a/docs/index.js
+++ b/docs/index.js
@@ -9,6 +9,7 @@ import spec from '../specs/openapi.json';
 const ui = SwaggerUI({
     spec,
     dom_id: '#swagger',
+    deepLinking: true
 });
 
 ui.initOAuth({

--- a/specs/openapi.json
+++ b/specs/openapi.json
@@ -38,8 +38,8 @@
             "name": "sitelinks",
             "description": "Wikibase Item Sitelinks",
             "externalDocs": {
-                "description": "Wikidata Glossary - Sitelinks",
-                "url" : "https://www.wikidata.org/wiki/Wikidata:Glossary#Sitelink"
+                "description": "Wikidata Data Model (JSON) - Sitelinks",
+                "url" : "https://www.mediawiki.org/wiki/Wikibase/DataModel/JSON#Site_Links"
             }
         },
         {
@@ -86,16 +86,16 @@
             "name": "qualifiers",
             "description": "Wikibase Statement Qualifiers",
             "externalDocs": {
-                "description": "Wikidata Glossary - Qualifier",
-                "url" : "https://www.wikidata.org/wiki/Wikidata:Glossary#Qualifier"
+                "description": "Wikibase Data Model - Snaks",
+                "url" : "https://www.mediawiki.org/wiki/Wikibase/DataModel#Snaks"
             }
         },
         {
             "name": "references",
             "description": "Wikibase Statement References",
             "externalDocs": {
-                "description": "Wikidata Glossary - Reference",
-                "url" : "https://www.wikidata.org/wiki/Wikidata:Glossary#References"
+                "description": "Wikidata Data Model - Reference Records",
+                "url" : "https://www.mediawiki.org/wiki/Wikibase/DataModel#ReferenceRecords"
             }
         }
     ],

--- a/specs/openapi.json
+++ b/specs/openapi.json
@@ -30,7 +30,7 @@
             "name": "items",
             "description": "Wikibase Items",
             "externalDocs": {
-                "description": "Wikibase Datamodel - Items",
+                "description": "Wikibase Data Model - Items",
                 "url" : "https://www.mediawiki.org/wiki/Wikibase/DataModel#Items"
             }
         },
@@ -38,7 +38,7 @@
             "name": "sitelinks",
             "description": "Wikibase Item Sitelinks",
             "externalDocs": {
-                "description": "Wikidata Data Model - Sitelinks",
+                "description": "Wikibase Data Model - Sitelinks",
                 "url" : "https://www.mediawiki.org/wiki/Wikibase/DataModel/JSON#Site_Links"
             }
         },

--- a/specs/openapi.json
+++ b/specs/openapi.json
@@ -38,7 +38,7 @@
             "name": "sitelinks",
             "description": "Wikibase Item Sitelinks",
             "externalDocs": {
-                "description": "Wikidata Data Model (JSON) - Sitelinks",
+                "description": "Wikidata Data Model - Sitelinks",
                 "url" : "https://www.mediawiki.org/wiki/Wikibase/DataModel/JSON#Site_Links"
             }
         },
@@ -46,7 +46,7 @@
             "name": "properties",
             "description": "Wikibase Properties",
             "externalDocs": {
-                "description": "Wikibase Datamodel - Properties",
+                "description": "Wikibase Data Model - Properties",
                 "url" : "https://www.mediawiki.org/wiki/Wikibase/DataModel#Properties"
             }
         },

--- a/specs/openapi.json
+++ b/specs/openapi.json
@@ -59,6 +59,14 @@
             }
         },
         {
+            "name": "descriptions",
+            "description": "Wikibase Entity Descriptions",
+            "externalDocs": {
+                "description": "Wikibase Data Model - Terms",
+                "url" : "https://www.mediawiki.org/wiki/Wikibase/DataModel#EntityDescriptions_of_Items_and_Properties"
+            }
+        },
+        {
             "name": "entities",
             "description": "Wikibase Entities",
             "externalDocs": {

--- a/specs/openapi.json
+++ b/specs/openapi.json
@@ -67,11 +67,11 @@
             }
         },
         {
-            "name": "entities",
-            "description": "Wikibase Entities",
+            "name": "aliases",
+            "description": "Wikibase Entity Aliases",
             "externalDocs": {
-                "description": "Wikibase Data Model - Values",
-                "url" : "https://www.mediawiki.org/wiki/Wikibase/DataModel#Values"
+                "description": "Wikibase Data Model - Terms",
+                "url" : "https://www.mediawiki.org/wiki/Wikibase/DataModel#EntityDescriptions_of_Items_and_Properties"
             }
         },
         {

--- a/specs/openapi.json
+++ b/specs/openapi.json
@@ -86,8 +86,8 @@
             "name": "qualifiers",
             "description": "Wikibase Statement Qualifiers",
             "externalDocs": {
-                "description": "Wikibase Data Model - Statements",
-                "url" : "https://www.mediawiki.org/wiki/Wikibase/DataModel#Statements"
+                "description": "Wikidata Glossary - Qualifier",
+                "url" : "https://www.wikidata.org/wiki/Wikidata:Glossary#Qualifier"
             }
         },
         {

--- a/specs/openapi.json
+++ b/specs/openapi.json
@@ -81,6 +81,22 @@
                 "description": "Wikibase Data Model - Statements",
                 "url" : "https://www.mediawiki.org/wiki/Wikibase/DataModel#Statements"
             }
+        },
+        {
+            "name": "qualifiers",
+            "description": "Wikibase Statement Qualifiers",
+            "externalDocs": {
+                "description": "Wikibase Data Model - Statements",
+                "url" : "https://www.mediawiki.org/wiki/Wikibase/DataModel#Statements"
+            }
+        },
+        {
+            "name": "references",
+            "description": "Wikibase Statement References",
+            "externalDocs": {
+                "description": "Wikibase Data Model - Statements",
+                "url" : "https://www.mediawiki.org/wiki/Wikibase/DataModel#Statements"
+            }
         }
     ],
     "paths": {

--- a/specs/openapi.json
+++ b/specs/openapi.json
@@ -35,11 +35,27 @@
             }
         },
         {
+            "name": "sitelinks",
+            "description": "Wikibase Item Sitelinks",
+            "externalDocs": {
+                "description": "Wikidata Glossary - Sitelinks",
+                "url" : "https://www.wikidata.org/wiki/Wikidata:Glossary#Sitelink"
+            }
+        },
+        {
             "name": "properties",
             "description": "Wikibase Properties",
             "externalDocs": {
                 "description": "Wikibase Datamodel - Properties",
                 "url" : "https://www.mediawiki.org/wiki/Wikibase/DataModel#Properties"
+            }
+        },
+        {
+            "name": "labels",
+            "description": "Wikibase Entity Labels",
+            "externalDocs": {
+                "description": "Wikibase Data Model - Terms",
+                "url" : "https://www.mediawiki.org/wiki/Wikibase/DataModel#EntityDescriptions_of_Items_and_Properties"
             }
         },
         {

--- a/specs/openapi.json
+++ b/specs/openapi.json
@@ -94,8 +94,8 @@
             "name": "references",
             "description": "Wikibase Statement References",
             "externalDocs": {
-                "description": "Wikibase Data Model - Statements",
-                "url" : "https://www.mediawiki.org/wiki/Wikibase/DataModel#Statements"
+                "description": "Wikidata Glossary - Reference",
+                "url" : "https://www.wikidata.org/wiki/Wikidata:Glossary#References"
             }
         }
     ],

--- a/specs/resources/aliases/list.json
+++ b/specs/resources/aliases/list.json
@@ -1,6 +1,6 @@
 {
     "get": {
-        "tags": [ "entities" ],
+        "tags": [ "aliases" ],
         "summary": "Retrieves an entity's alias lists",
         "parameters": [
             { "$ref": "../../global/parameters.json#/entityType" },
@@ -19,7 +19,7 @@
         }
     },
     "patch": {
-        "tags": [ "entities" ],
+        "tags": [ "aliases" ],
         "summary": "Updates an entity's alias lists",
         "parameters": [
             { "$ref": "../../global/parameters.json#/entityType" },

--- a/specs/resources/aliases/singleLang.json
+++ b/specs/resources/aliases/singleLang.json
@@ -1,6 +1,6 @@
 {
     "get": {
-        "tags": [ "entities" ],
+        "tags": [ "aliases" ],
         "summary": "Retrieves an entity's alias list by language",
         "parameters": [
             { "$ref": "../../global/parameters.json#/entityType" },
@@ -19,7 +19,7 @@
         }
     },
     "put": {
-        "tags": ["entities"],
+        "tags": ["aliases"],
         "summary": "Add / Replace a whole alias list by language",
         "parameters": [
             { "$ref": "../../global/parameters.json#/entityType" },
@@ -36,7 +36,7 @@
         }
     },
     "patch": {
-        "tags": [ "entities" ],
+        "tags": [ "aliases" ],
         "summary": "Updates an entity's alias list by language",
         "parameters": [
             { "$ref": "../../global/parameters.json#/entityType" },
@@ -53,7 +53,7 @@
         }
     },
     "delete": {
-        "tags": [ "entities" ],
+        "tags": [ "aliases" ],
         "summary": "Deletes an entity's alias list by language",
         "parameters": [
             { "$ref": "../../global/parameters.json#/entityType" },

--- a/specs/resources/descriptions/list.json
+++ b/specs/resources/descriptions/list.json
@@ -1,6 +1,6 @@
 {
     "get": {
-        "tags": [ "entities" ],
+        "tags": [ "descriptions" ],
         "summary": "Retrieves an entity's description list",
         "parameters": [
             { "$ref": "../../global/parameters.json#/entityType" },
@@ -21,7 +21,7 @@
         }
     },
     "patch": {
-        "tags": [ "entities" ],
+        "tags": [ "descriptions" ],
         "summary": "Updates an entity's description list",
         "parameters": [
             { "$ref": "../../global/parameters.json#/entityType" },

--- a/specs/resources/descriptions/singleLang.json
+++ b/specs/resources/descriptions/singleLang.json
@@ -1,6 +1,6 @@
 {
     "get": {
-        "tags": [ "entities" ],
+        "tags": [ "descriptions" ],
         "summary": "Retrieves an entity's description by language",
         "parameters": [
             { "$ref": "../../global/parameters.json#/entityType" },
@@ -17,7 +17,7 @@
         }
     },
     "put": {
-        "tags": ["entities"],
+        "tags": ["descriptions"],
         "summary": "Add / Replace a description to an entity by language",
         "parameters": [
             { "$ref": "../../global/parameters.json#/entityType" },
@@ -34,7 +34,7 @@
         }
     },
     "delete": {
-        "tags": [ "entities" ],
+        "tags": [ "descriptions" ],
         "summary": "Deletes an entity's description by language",
         "parameters": [
             { "$ref": "../../global/parameters.json#/entityType" },

--- a/specs/resources/labels/list.json
+++ b/specs/resources/labels/list.json
@@ -1,6 +1,6 @@
 {
     "get": {
-        "tags": [ "entities" ],
+        "tags": [ "labels" ],
         "summary": "Retrieves an entity's labels list",
         "parameters": [
             { "$ref": "../../global/parameters.json#/entityType" },
@@ -19,7 +19,7 @@
         }
     },
     "patch": {
-        "tags": [ "entities" ],
+        "tags": [ "labels" ],
         "summary": "Updates an entity's label list",
         "parameters": [
             { "$ref": "../../global/parameters.json#/entityType" },

--- a/specs/resources/labels/singleLang.json
+++ b/specs/resources/labels/singleLang.json
@@ -1,6 +1,6 @@
 {
     "get": {
-        "tags": [ "entities" ],
+        "tags": [ "labels" ],
         "summary": "Retrieve an entity's label by language",
         "parameters": [
             { "$ref": "../../global/parameters.json#/entityType" },
@@ -17,7 +17,7 @@
         }
     },
     "put": {
-        "tags": ["entities"],
+        "tags": ["labels"],
         "summary": "Add / Replace a label to an entity by language",
         "parameters": [
             { "$ref": "../../global/parameters.json#/entityType" },
@@ -32,7 +32,7 @@
         }
     },
     "delete": {
-        "tags": [ "entities" ],
+        "tags": [ "labels" ],
         "summary": "Delete an entity's label by language",
         "parameters": [
             { "$ref": "../../global/parameters.json#/entityType" },

--- a/specs/resources/qualifiers/list.json
+++ b/specs/resources/qualifiers/list.json
@@ -1,6 +1,6 @@
 {
     "get": {
-        "tags": [ "statements" ],
+        "tags": [ "qualifiers" ],
         "summary": "Lists qualifiers for a Statement",
         "description": "This endpoint is also accessible through `/entities/{entity_type}/{entity_id}/statements/{statement_id}/qualifiers`",
         "parameters": [
@@ -20,7 +20,7 @@
         }
     },
     "post": {
-        "tags": ["statements"],
+        "tags": ["qualifiers"],
         "summary": "Add a new Qualifier to a Statement",
         "description": "This endpoint is also accessible through `/entities/{entity_type}/{entity_id}/statements/{statement_id}/qualifiers`",
         "parameters": [

--- a/specs/resources/qualifiers/single.json
+++ b/specs/resources/qualifiers/single.json
@@ -1,6 +1,6 @@
 {
     "get": {
-        "tags": [ "statements" ],
+        "tags": [ "qualifiers" ],
         "summary": "Single qualifier by hash",
         "description": "This endpoint is also accessible through `/entities/{entity_type}/{entity_id}/statements/{statement_id}/qualifiers/{qualifierHash}`",
         "parameters": [
@@ -18,7 +18,7 @@
         }
     },
     "post": {
-        "tags": ["statements"],
+        "tags": ["qualifiers"],
         "summary": "Update a qualifier",
         "description": "This endpoint is also accessible through `/entities/{entity_type}/{entity_id}/statements/{statement_id}/qualifiers/{qualifierHash}`",
         "parameters": [
@@ -35,7 +35,7 @@
         }
     },
     "delete": {
-        "tags": [ "statements" ],
+        "tags": [ "qualifiers" ],
         "summary": "Single qualifier by hash",
         "description": "This endpoint is also accessible through `/entities/{entity_type}/{entity_id}/statements/{statement_id}/qualifiers/{qualifier_hash}`",
         "parameters": [

--- a/specs/resources/references/list.json
+++ b/specs/resources/references/list.json
@@ -1,6 +1,6 @@
 {
     "get": {
-        "tags": [ "statements" ],
+        "tags": [ "references" ],
         "summary": "Lists references for a Statement",
         "description": "This endpoint is also accessible through `/entities/{entity_type}/{entity_id}/statements/{statement_id}/references`",
         "parameters": [
@@ -20,7 +20,7 @@
         }
     },
     "post": {
-        "tags": ["statements"],
+        "tags": ["references"],
         "summary": "Add a new Reference to a Statement",
         "description": "This endpoint is also accessible through `/entities/{entity_type}/{entity_id}/statements/{statement_id}/references`",
         "parameters": [

--- a/specs/resources/references/single.json
+++ b/specs/resources/references/single.json
@@ -1,6 +1,6 @@
 {
     "get": {
-        "tags": [ "statements" ],
+        "tags": [ "references" ],
         "summary": "Single reference by hash",
         "description": "This endpoint is also accessible through `/entities/{entity_type}/{entity_id}/statements/{statement_id}/references/{reference_hash}`",
         "parameters": [
@@ -18,7 +18,7 @@
         }
     },
     "post": {
-        "tags": ["statements"],
+        "tags": ["references"],
         "summary": "Update a reference",
         "description": "This endpoint is also accessible through `/entities/{entity_type}/{entity_id}/statements/{statement_id}/references/{reference_hash}`",
         "parameters": [
@@ -35,7 +35,7 @@
         }
     },
     "delete": {
-        "tags": [ "statements" ],
+        "tags": [ "references" ],
         "summary": "Single reference by hash",
         "description": "This endpoint is also accessible through `/entities/{entity_type}/{entity_id}/statements/{statement_id}/references/{reference_hash}`",
         "parameters": [

--- a/specs/resources/sitelinks/list.json
+++ b/specs/resources/sitelinks/list.json
@@ -1,6 +1,6 @@
 {
     "get": {
-        "tags": [ "items" ],
+        "tags": [ "sitelinks" ],
         "summary": "Retrieves an item's sitelinks",
         "parameters": [
             { "$ref": "../../global/parameters.json#/entityId" },
@@ -18,7 +18,7 @@
         }
     },
     "post": {
-        "tags": [ "items" ],
+        "tags": [ "sitelinks" ],
         "summary": "Creates an item's sitelink",
         "parameters": [
             { "$ref": "../../global/parameters.json#/entityId" }

--- a/specs/resources/sitelinks/single.json
+++ b/specs/resources/sitelinks/single.json
@@ -1,6 +1,6 @@
 {
     "get": {
-        "tags": [ "items" ],
+        "tags": [ "sitelinks" ],
         "summary": "Retrieves an Item's sitelink by wiki-id",
         "parameters": [
             { "$ref": "../../global/parameters.json#/entityId" },
@@ -16,7 +16,7 @@
         }
     },
     "patch": {
-        "tags": [ "items" ],
+        "tags": [ "sitelinks" ],
         "summary": "Updates an Item's sitelink by wiki-id",
         "parameters": [
             { "$ref": "../../global/parameters.json#/entityId" },
@@ -32,7 +32,7 @@
         }
     },
     "delete": {
-        "tags": [ "items" ],
+        "tags": [ "sitelinks" ],
         "summary": "Item's sitelink by wiki-id",
         "parameters": [
             { "$ref": "../../global/parameters.json#/entityId" },

--- a/specs/resources/statements/list.json
+++ b/specs/resources/statements/list.json
@@ -1,6 +1,6 @@
 {
     "get": {
-        "tags": ["entities", "statements"],
+        "tags": ["statements"],
         "summary": "Retrieve a list of entity Statements",
         "parameters": [
             { "$ref": "../../global/parameters.json#/entityType" },
@@ -20,7 +20,7 @@
         }
     },
     "post": {
-        "tags": ["entities", "statements"],
+        "tags": ["statements"],
         "summary": "Add a new Statement to an entity (Item | Property)",
         "parameters": [
             { "$ref": "../../global/parameters.json#/entityType" },


### PR DESCRIPTION
While working on PR #75 I noticed that it is possible to make the UI of the spec a little more digestible if we separate the tags by available resource. This makes it clearer which kind of data you are requesting / operating on.