### PR TITLE
SwaggerParser: disallow http-based $refs

### DIFF
--- a/loaders/openapi-loader.js
+++ b/loaders/openapi-loader.js
@@ -6,7 +6,15 @@ module.exports = function (_) {
 
     this.addContextDependency( path.dirname( this.resourcePath ) );
 
-    SwaggerParser.bundle(this.resourcePath)
+    SwaggerParser
+        .bundle(
+            this.resourcePath,
+            {
+                resolve: {
+                    http: false,
+                },
+            },
+        )
         .then(spec => done(null, JSON.stringify(spec)))
         .catch(({message}) => done(message))
 } 


### PR DESCRIPTION
All contributors are trusted so there is no real risk involved yet there
is currently no existing use and settings it makes this explicit.

See
https://github.com/APIDevTools/swagger-parser/blob/c47b3f5/docs/options.md