### PR TITLE
label/description - language mapping: use right tech terms

### DIFF
--- a/specs/global/responses.json
+++ b/specs/global/responses.json
@@ -195,7 +195,7 @@
             }
         }
     },
-    "EntityDescriptionList": {
+    "EntityDescriptionMap": {
         "description": "Entity Description by language",
         "headers": {
             "Last-Modified": {
@@ -217,7 +217,7 @@
             }
         }
     },
-    "EntityLabelList": {
+    "EntityLabelMap": {
         "description": "Entity Label by language",
         "headers": {
             "Last-Modified": {

--- a/specs/resources/descriptions/list.json
+++ b/specs/resources/descriptions/list.json
@@ -1,7 +1,7 @@
 {
     "get": {
         "tags": [ "entities" ],
-        "summary": "Retrieves an entity's description list",
+        "summary": "Retrieves an entity's description map",
         "parameters": [
             { "$ref": "../../global/parameters.json#/entityType" },
             { "$ref": "../../global/parameters.json#/entityId" },
@@ -12,7 +12,7 @@
             { "$ref": "../../global/parameters.json#/ifModifiedSince" }
         ],
         "responses": {
-            "200": { "$ref": "../../global/responses.json#/EntityDescriptionList" },
+            "200": { "$ref": "../../global/responses.json#/EntityDescriptionMap" },
             "304": { "$ref": "../../global/responses.json#/NotModified" },
             "404": { "$ref": "../../global/responses.json#/NotFound" },
             "501": { "$ref": "../../global/responses.json#/UnauthenticatedError" },
@@ -22,14 +22,14 @@
     },
     "patch": {
         "tags": [ "entities" ],
-        "summary": "Updates an entity's description list",
+        "summary": "Updates an entity's description map",
         "parameters": [
             { "$ref": "../../global/parameters.json#/entityType" },
             { "$ref": "../../global/parameters.json#/entityId" }
         ],
         "requestBody": { "$ref": "../../global/requests.json#/PatchList" },
         "responses": {
-            "200": { "$ref": "../../global/responses.json#/EntityDescriptionList" },
+            "200": { "$ref": "../../global/responses.json#/EntityDescriptionMap" },
             "404": { "$ref": "../../global/responses.json#/NotFound" },
             "501": { "$ref": "../../global/responses.json#/UnauthenticatedError" },
             "503": { "$ref": "../../global/responses.json#/UnauthorizedError" },

--- a/specs/resources/labels/list.json
+++ b/specs/resources/labels/list.json
@@ -1,7 +1,7 @@
 {
     "get": {
         "tags": [ "entities" ],
-        "summary": "Retrieves an entity's labels list",
+        "summary": "Retrieves an entity's labels map",
         "parameters": [
             { "$ref": "../../global/parameters.json#/entityType" },
             { "$ref": "../../global/parameters.json#/entityId" },
@@ -12,7 +12,7 @@
             { "$ref": "../../global/parameters.json#/ifModifiedSince" }
         ],
         "responses": {
-            "200": { "$ref": "../../global/responses.json#/EntityLabelList" },
+            "200": { "$ref": "../../global/responses.json#/EntityLabelMap" },
             "304": { "$ref": "../../global/responses.json#/NotModified" },
             "404": { "$ref": "../../global/responses.json#/NotFound" },
             "default": { "$ref": "../../global/responses.json#/UnexpectedError" }
@@ -20,14 +20,14 @@
     },
     "patch": {
         "tags": [ "entities" ],
-        "summary": "Updates an entity's label list",
+        "summary": "Updates an entity's labels map",
         "parameters": [
             { "$ref": "../../global/parameters.json#/entityType" },
             { "$ref": "../../global/parameters.json#/entityId" }
         ],
         "requestBody": { "$ref": "../../global/requests.json#/PatchList" },
         "responses": {
-            "200": { "$ref": "../../global/responses.json#/EntityLabelList" },
+            "200": { "$ref": "../../global/responses.json#/EntityLabelMap" },
             "404": { "$ref": "../../global/responses.json#/NotFound" },
             "default": { "$ref": "../../global/responses.json#/UnexpectedError" }
         }


### PR DESCRIPTION
This has been using technical terminology (list instead of map) but in a
way which, at least with me, created a wrong association.

Both labels and descriptions are maps of terms (indexed by language),
not lists.