### PR TITLE
Add finishing touches

### DIFF
--- a/docs/index.js
+++ b/docs/index.js
@@ -8,7 +8,8 @@ import spec from '../specs/openapi.json';
 const ui = SwaggerUI({
     spec,
     dom_id: '#swagger',
-    deepLinking: true
+    deepLinking: true,
+    defaultModelRendering: "model"
 });
 
 ui.initOAuth({

--- a/specs/global/interfaces.json
+++ b/specs/global/interfaces.json
@@ -7,10 +7,6 @@
             },
             "type": {
                 "type": "string"
-            },
-            "modified": {
-                "type": "string",
-                "format": "date-time"
             }
         },
 		"required": [


### PR DESCRIPTION
As discussed, setting the payload preview to schema (rather than example) and removing the `modified` key from the entity interface