### PR TITLE
QualifierHash, ReferenceHash: move out of listed schemas

### DIFF
--- a/specs/global/interfaces.json
+++ b/specs/global/interfaces.json
@@ -121,6 +121,16 @@
         "type": "string",
         "example": "455481eeac76e6a8af71a6b493c073d54788e7e9"
     },
+    "QualifierHash": {
+        "description": "Hash of a qualifier",
+        "type": "string",
+        "example": "455481eeac76e6a8af71a6b493c073d54788e7e9"
+    },
+    "ReferenceHash": {
+        "description": "Hash of a reference",
+        "type": "string",
+        "example": "455481eeac76e6a8af71a6b493c073d54788e7e9"
+    },
     "Snaks": {
         "type": "object",
         "additionalProperties": {

--- a/specs/global/parameters.json
+++ b/specs/global/parameters.json
@@ -88,7 +88,7 @@
         "description": "Single qualifier by hash",
         "required": true,
         "schema": {
-            "$ref": "./schemas.json#/QualifierHash"
+            "$ref": "./interfaces.json#/QualifierHash"
         }
     },
     "referenceHash": {
@@ -97,7 +97,7 @@
         "description": "Single reference by hash",
         "required": true,
         "schema": {
-            "$ref": "./schemas.json#/ReferenceHash"
+            "$ref": "./interfaces.json#/ReferenceHash"
         }
     },
     "statementId": {

--- a/specs/global/schemas.json
+++ b/specs/global/schemas.json
@@ -128,16 +128,6 @@
             "value"
         ]
     },
-    "QualifierHash": {
-        "description": "Hash of a qualifier",
-        "type": "string",
-        "example": "455481eeac76e6a8af71a6b493c073d54788e7e9"
-    },
-    "ReferenceHash": {
-        "description": "Hash of a reference",
-        "type": "string",
-        "example": "455481eeac76e6a8af71a6b493c073d54788e7e9"
-    },
     "Snak":{
         "$ref": "./interfaces.json#/Snak"
     },


### PR DESCRIPTION
They are arguably not "top level" things we want to point people to.