### PR TITLE
statements: don't list entity types which have them

### DIFF
--- a/specs/resources/statements/single.json
+++ b/specs/resources/statements/single.json
@@ -1,7 +1,7 @@
 {
     "get": {
         "tags": [ "statements" ],
-        "summary": "Retrieves a single Statement from an entity (items | properties)",
+        "summary": "Retrieves a single Statement from an entity",
         "description": "This endpoint is also accessible through `/entities/{entity_type}/{entity_id}/statements/{statement_id}`",
         "parameters": [
             { "$ref": "../../global/parameters.json#/statementId" },
@@ -48,7 +48,7 @@
     },
     "delete": {
         "tags": [ "statements" ],
-        "summary": "Single statement from an entity (items | properties)",
+        "summary": "Single statement from an entity",
         "description": "This endpoint is also accessible through `/entities/{entity_type}/{entity_id}/statements/{statement_id}`",
         "parameters": [
             { "$ref": "../../global/parameters.json#/statementId" }


### PR DESCRIPTION
Thinking of extensibility, what looks like a list of useful examples
could also be interpreted as an exhaustive list - and it would be wrong
in case of e.g. lexemes.