### PR TITLE
items, properties: collections have no 404

### DIFF
--- a/specs/resources/items/list.json
+++ b/specs/resources/items/list.json
@@ -10,7 +10,6 @@
         ],
         "responses": {
             "200": { "$ref": "../../global/responses.json#/ItemList" },
-            "404": { "$ref": "../../global/responses.json#/NotFound" },
             "default": { "$ref": "../../global/responses.json#/UnexpectedError" }
         }
     },

--- a/specs/resources/properties/list.json
+++ b/specs/resources/properties/list.json
@@ -10,7 +10,6 @@
         ],
         "responses": {
             "200": { "$ref": "../../global/responses.json#/PropertyList" },
-            "404": { "$ref": "../../global/responses.json#/NotFound" },
             "default": { "$ref": "../../global/responses.json#/UnexpectedError" }
         }
     },


### PR DESCRIPTION
The collections may be empty but should not show a 404. The secenario in
which something like this could happen is if an entity type does not
exist, but the way we present the paths (with hard coded /items and
/properties) this is not the case here.

Bug: https://phabricator.wikimedia.org/T264551