### PR TITLE
Changed link to data model JSON docs

### DIFF
--- a/specs/global/parameters.json
+++ b/specs/global/parameters.json
@@ -2,7 +2,7 @@
     "fields": {
         "in": "query",
         "name": "_fields",
-        "description": "Comma separated list of fields to include in each response object. See [JSON Data Model](https://www.mediawiki.org/wiki/Wikibase/DataModel/JSON) for field names.",
+        "description": "Comma separated list of fields to include in each response object. See [JSON Data Model](https://doc.wikimedia.org/Wikibase/master/php/md_docs_topics_json.html) for field names.",
         "required": false,
         "style": "form",
         "explode": false,


### PR DESCRIPTION
Changed to a direct link, given the documentation page
on Mediawiki is now only pointing to in-git documentation.